### PR TITLE
Issue with MAILER_TYPE variable in configmap

### DIFF
--- a/roles/gitea-ocp/templates/configmap.yaml.j2
+++ b/roles/gitea-ocp/templates/configmap.yaml.j2
@@ -50,7 +50,7 @@ data:
     ENABLED = {{ _gitea_mailer_enabled | bool }}
     {% if _gitea_mailer_enabled | bool %}
     FROM           = {{ _gitea_mailer_from }}
-    MAILER_TYPE    = {{ _gitea_mailer_type }}
+    PROTOCOL       = {{ _gitea_mailer_type }}
     HOST           = {{ _gitea_mailer_host }}
     IS_TLS_ENABLED = {{ _gitea_mailer_tls | bool }}
     USER           = {{ _gitea_mailer_user }}


### PR DESCRIPTION
Hello everyone,

@bodz1lla and I found out that there is a bug in the mail server configuration of the Gitea instance spawned by the operator.

Apparently the variable MAILER_TYPE which is needed for email service is not used anymore. 
You can see the error message in the Gitea settings, if you enable mail config as described in your documentation [here](https://github.com/rhpds/gitea-operator/tree/main#set-up-e-mail-service)

![image](https://github.com/rhpds/gitea-operator/assets/33745958/4ec2415a-8dca-46e3-bccd-3e8ba55f71f6)

As described in the official Gitea documentation [here](https://docs.gitea.com/next/administration/email-setup#using-smtp) and the code [here](https://github.com/go-gitea/gitea/blob/f48a863b99a8075da290f9dc85d8296c974fb86b/modules/setting/mailer.go#L70), the fix would be to change the MAILER_TYPE variable to PROTOCOL in the configmap [here](https://github.com/rhpds/gitea-operator/blob/main/roles/gitea-ocp/templates/configmap.yaml.j2)

This is currently blocking us from configuring the mailserver for our Gitea deployment.

Any help would be appreciated :)