### PR TITLE
Updated Mailer configuration options to resolve deprecation issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ bin
 *.swp
 *.swo
 *~
+
+# Ignore .vscode folder
+.vscode/

--- a/README.adoc
+++ b/README.adoc
@@ -255,8 +255,9 @@ metadata:
 spec:
   giteaMailerEnabled: true
   giteaMailerFrom: gmail-user@gmail.com
-  giteaMailerType: smtp
-  giteaMailerHost: smtp.gmail.com:465
+  giteaMailerProtocol: smtps
+  giteaMailerHost: smtp.gmail.com
+  giteaMailerPort: 465
   giteaMailerUser: gmail-user@gmail.com
   giteaMailerPassword: gmail-user-app-specific-password
   giteaMailerTls: true
@@ -610,11 +611,14 @@ giteaMailerEnabled:
 giteaMailerFrom:
   description: 'E-mail integration. FROM e-mail address to be used. Default: ""'
   type: string
-giteaMailerType:
-  description: 'Type of e-mail provider to be used. Default: smtp'
+giteaMailerProtocol:
+  description: 'Protocol of e-mail provider to be used. Default: smtps'
   type: string
 giteaMailerHost:
   description: 'Hostname of the e-mail server to be used. Default: ""'
+  type: string
+giteaMailerPort:
+  description: 'Port of the e-mail server to be used. Default: ""'
   type: string
 giteaMailerTls:
   description: 'Use TLS encryption when connecting to the mailer host. Default: true'

--- a/bundle/manifests/pfe.rhpds.com_gitea.yaml
+++ b/bundle/manifests/pfe.rhpds.com_gitea.yaml
@@ -152,6 +152,10 @@ spec:
                 description: Hostname of the e-mail server to be used. Default is
                   "".
                 type: string
+              giteaMailerPort:
+                description: Port of the e-mail server to be used. Default is
+                  "".
+                type: string
               giteaMailerPassword:
                 description: Password for the User ID on the e-mail server to be used.
                   May need to be an app-specific password if two-factor authentication
@@ -161,8 +165,8 @@ spec:
                 description: Use TLS encryption when connecting to the mailer host.
                   Default is true.
                 type: boolean
-              giteaMailerType:
-                description: Type of e-mail provider to be used. Default is smtp.
+              giteaMailerProtocol:
+                description: Protocol of e-mail provider to be used. Default is smtp.
                 type: string
               giteaMailerUser:
                 description: User ID on the e-mail server to use. Frequently the same

--- a/config/crd/patches/crd_openapi.yaml
+++ b/config/crd/patches/crd_openapi.yaml
@@ -253,11 +253,14 @@ spec:
               giteaMailerFrom:
                 description: E-mail integration. FROM e-mail address to be used. Default is "".
                 type: string
-              giteaMailerType:
-                description: Type of e-mail provider to be used. Default is smtp.
+              giteaMailerProtocol:
+                description: Protocol of e-mail provider to be used. Default is smtps.
                 type: string
               giteaMailerHost:
                 description: Hostname of the e-mail server to be used. Default is "".
+                type: string
+              giteaMailerPort:
+                description: Port of the e-mail server to be used. Default is "".
                 type: string
               giteaMailerTls:
                 description: Use TLS encryption when connecting to the mailer host. Default is true.

--- a/playbooks/gitea.yml
+++ b/playbooks/gitea.yml
@@ -93,8 +93,9 @@
 
       _gitea_mailer_enabled: "{{ gitea_mailer_enabled | default(false) | bool }}"
       _gitea_mailer_from: "{{ gitea_mailer_from | default('') }}"
-      _gitea_mailer_type: "{{ gitea_mailer_type | default('smtp') }}"
+      _gitea_mailer_protocol: "{{ gitea_mailer_protocol | default('smtps') }}"
       _gitea_mailer_host: "{{ gitea_mailer_host | default('') }}"
+      _gitea_mailer_port: "{{ gitea_mailer_port | default('') }}"
       _gitea_mailer_tls: "{{ gitea_mailer_tls | default(true) | bool }}"
       _gitea_mailer_user: "{{ gitea_mailer_user | default('') }}"
       _gitea_mailer_password: "{{ gitea_mailer_password | default('') }}"

--- a/roles/gitea-ocp/defaults/main.yml
+++ b/roles/gitea-ocp/defaults/main.yml
@@ -92,8 +92,9 @@ _gitea_webhook_skip_tls_verify: false
 # Gitea e-mail Setup
 _gitea_mailer_enabled: false
 _gitea_mailer_from: gitea@mydomain.com
-_gitea_mailer_type: smtp
-_gitea_mailer_host: mail.mydomain.com:587
+_gitea_mailer_protocol: smtps
+_gitea_mailer_host: mail.mydomain.com
+_gitea_mailer_port: 465
 _gitea_mailer_tls: true
 _gitea_mailer_user: gitea@mydomain.com
 _gitea_mailer_password: password

--- a/roles/gitea-ocp/templates/configmap.yaml.j2
+++ b/roles/gitea-ocp/templates/configmap.yaml.j2
@@ -50,15 +50,12 @@ data:
     ENABLED = {{ _gitea_mailer_enabled | bool }}
     {% if _gitea_mailer_enabled | bool %}
     FROM           = {{ _gitea_mailer_from }}
-    PROTOCOL       = {{ _gitea_mailer_type }}
-    HOST           = {{ _gitea_mailer_host }}
+    PROTOCOL       = {{ _gitea_mailer_protocol }}
+    SMTP_ADDR      = {{ _gitea_mailer_host }}
+    SMTP_PORT      = {{ _gitea_mailer_port }}
     IS_TLS_ENABLED = {{ _gitea_mailer_tls | bool }}
     USER           = {{ _gitea_mailer_user }}
     PASSWD         = `{{ _gitea_mailer_password }}`
-    {%    if _gitea_mailer_helo_hostname | default("") | length > 0 %}
-    HELO_HOSTNAME  = {{ _gitea_mailer_helo_hostname }}
-    {%    endif %}
-    {% endif %}
 
     [service]
     REGISTER_EMAIL_CONFIRM            = {{ _gitea_register_email_confirm | bool }}


### PR DESCRIPTION
After new release, the another new deprecation was found.

![Screenshot 2023-11-09 at 18 03 54](https://github.com/rhpds/gitea-operator/assets/19761842/c1a05166-bec5-4bc1-97a8-6e07103db3d1)

This fix updates the CRD, changes the variable from HOST to SMTP_ADDR, and adds an additional variable SMTP_PORT.