### PR TITLE
change manager limit and request

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -96,9 +96,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 768Mi
+            memory: 2Gi
           requests:
             cpu: 10m
-            memory: 256Mi
+            memory: 768Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Changed manager limit and request because of: https://github.com/rhpds/gitea-operator/issues/28

Actually in my test the manager required close to 1Gi so the limit killed the pod before it finished the ansible playbook.